### PR TITLE
ENH: Add frequency domain seasonal components to UnobservedComponents

### DIFF
--- a/examples/notebooks/statespace_seasonal.ipynb
+++ b/examples/notebooks/statespace_seasonal.ipynb
@@ -1,0 +1,453 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Seasonality in time series data\n",
+    "\n",
+    "Consider the problem of modeling time series data with multiple seasonal components with different perioidicities.  Let us take the time series $y_t$ and decompose it explicitly to have a level component and two seasonal components.\n",
+    "\n",
+    "$$\n",
+    "y_t = \\mu_t + \\gamma^{(1)}_t + \\gamma^{(2)}_t\n",
+    "$$\n",
+    "\n",
+    "where $\\mu_t$ represents the trend or level, $\\gamma^{(1)}_t$ represents a seasonal component with a relatively short period, and $\\gamma^{(2)}_t$ represents another seasonal component of longer period. We will have a fixed intercept term for our level and consider both $\\gamma^{(2)}_t$ and $\\gamma^{(2)}_t$ to be stochastic so that the seasonal patterns can vary over time.\n",
+    "\n",
+    "In this notebook, we will generate synthetic data conforming to this model and showcase modeling of the seasonal terms in a few different ways under the unobserved components modeling framework."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import statsmodels.api as sm\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Synthetic data creation\n",
+    "\n",
+    "We will create data with multiple seasonal patterns by following equations (3.7) and (3.8) in Durbin and Koopman (2012).  We will simulate 300 periods and two seasonal terms parameterized in the frequency domain having periods 10 and 100, respectively, and 3 and 2 number of harmonics, respectively.  Further, the variances of their stochastic parts are 4 and 9, respecively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# First we'll simulate the synthetic data\n",
+    "def simulate_seasonal_term(periodicity, total_cycles, noise_std=1.,\n",
+    "                           harmonics=None):\n",
+    "    duration = periodicity * total_cycles\n",
+    "    assert duration == int(duration)\n",
+    "    duration = int(duration)\n",
+    "    harmonics = harmonics if harmonics else int(np.floor(periodicity / 2))\n",
+    "\n",
+    "    lambda_p = 2 * np.pi / float(periodicity)\n",
+    "\n",
+    "    gamma_jt = noise_std * np.random.randn((harmonics))\n",
+    "    gamma_star_jt = noise_std * np.random.randn((harmonics))\n",
+    "\n",
+    "    total_timesteps = 100 * duration # Pad for burn in\n",
+    "    series = np.zeros(total_timesteps) \n",
+    "    for t in range(total_timesteps):\n",
+    "        gamma_jtp1 = np.zeros_like(gamma_jt)\n",
+    "        gamma_star_jtp1 = np.zeros_like(gamma_star_jt)\n",
+    "        for j in range(1, harmonics + 1):\n",
+    "            cos_j = np.cos(lambda_p * j)\n",
+    "            sin_j = np.sin(lambda_p * j)\n",
+    "            gamma_jtp1[j - 1] = (gamma_jt[j - 1] * cos_j\n",
+    "                                 + gamma_star_jt[j - 1] * sin_j\n",
+    "                                 + noise_std * np.random.randn())\n",
+    "            gamma_star_jtp1[j - 1] = (- gamma_jt[j - 1] * sin_j\n",
+    "                                      + gamma_star_jt[j - 1] * cos_j\n",
+    "                                      + noise_std * np.random.randn())\n",
+    "        series[t] = np.sum(gamma_jtp1)\n",
+    "        gamma_jt = gamma_jtp1\n",
+    "        gamma_star_jt = gamma_star_jtp1\n",
+    "    wanted_series = series[-duration:] # Discard burn in\n",
+    "\n",
+    "    return wanted_series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duration = 100 * 3\n",
+    "periodicities = [10, 100]\n",
+    "num_harmonics = [3, 2]\n",
+    "std = np.array([2, 3])\n",
+    "np.random.seed(8678309)\n",
+    "\n",
+    "terms = []\n",
+    "for ix, _ in enumerate(periodicities):\n",
+    "    s = simulate_seasonal_term(\n",
+    "        periodicities[ix],\n",
+    "        duration / periodicities[ix],\n",
+    "        harmonics=num_harmonics[ix],\n",
+    "        noise_std=std[ix])\n",
+    "    terms.append(s)\n",
+    "terms.append(np.ones_like(terms[0]) * 10.)\n",
+    "series = pd.Series(np.sum(terms, axis=0))\n",
+    "df = pd.DataFrame(data={'total': series,\n",
+    "                        '10(3)': terms[0],\n",
+    "                        '100(2)': terms[1],\n",
+    "                        'level':terms[2]})\n",
+    "h1, = plt.plot(df['total'])\n",
+    "h2, = plt.plot(df['10(3)'])\n",
+    "h3, = plt.plot(df['100(2)'])\n",
+    "h4, = plt.plot(df['level'])\n",
+    "plt.legend(['total','10(3)','100(2)', 'level'])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Unobserved components (frequency domain modeling)\n",
+    "\n",
+    "The next method is an unobserved components model, where the trend is modeled as a fixed intercept and the seasonal components are modeled using trigonometric functions with primary periodicities of 10 and 100, respectively, and number of harmonics 3 and 2, respecively.  Note that this is the correct, generating model. The process for the time series can be written as:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "y_t & = \\mu_t + \\gamma^{(1)}_t + \\gamma^{(2)}_t + \\epsilon_t\\\\\n",
+    "\\mu_{t+1} & = \\mu_t \\\\\n",
+    "\\gamma^{(1)}_{t} &= \\sum_{j=1}^2 \\gamma^{(1)}_{j, t} \\\\\n",
+    "\\gamma^{(2)}_{t} &= \\sum_{j=1}^3 \\gamma^{(2)}_{j, t}\\\\\n",
+    "\\gamma^{(1)}_{j, t+1} &= \\gamma^{(1)}_{j, t}\\cos(\\lambda_j) + \\gamma^{*, (1)}_{j, t}\\sin(\\lambda_j) + \\omega^{(1)}_{j,t}, ~j = 1, 2, 3\\\\\n",
+    "\\gamma^{*, (1)}_{j, t+1} &= -\\gamma^{(1)}_{j, t}\\sin(\\lambda_j) + \\gamma^{*, (1)}_{j, t}\\cos(\\lambda_j) + \\omega^{*, (1)}_{j, t}, ~j = 1, 2, 3\\\\\n",
+    "\\gamma^{(2)}_{j, t+1} &= \\gamma^{(2)}_{j, t}\\cos(\\lambda_j) + \\gamma^{*, (2)}_{j, t}\\sin(\\lambda_j) + \\omega^{(2)}_{j,t}, ~j = 1, 2\\\\\n",
+    "\\gamma^{*, (2)}_{j, t+1} &= -\\gamma^{(2)}_{j, t}\\sin(\\lambda_j) + \\gamma^{*, (2)}_{j, t}\\cos(\\lambda_j) + \\omega^{*, (2)}_{j, t}, ~j = 1, 2\\\\\n",
+    "\\end{align}\n",
+    "$$\n",
+    "$$\n",
+    "\n",
+    "where $\\epsilon_t$ is white noise, $\\omega^{(1)}_{j,t}$ are i.i.d. $N(0, \\sigma^2_1)$, and  $\\omega^{(2)}_{j,t}$ are i.i.d. $N(0, \\sigma^2_2)$, where $\\sigma_1 = 2.$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "model = sm.tsa.UnobservedComponents(series.values, \n",
+    "                                    level='fixed intercept', \n",
+    "                                    freq_seasonal=[{'period': 10,\n",
+    "                                                    'harmonics': 3},\n",
+    "                                                   {'period': 100,\n",
+    "                                                    'harmonics': 2}])\n",
+    "res_f = model.fit(disp=False)\n",
+    "print(res_f.summary())\n",
+    "# The first state variable holds our estimate of the intercept\n",
+    "print(\"fixed intercept estimated as {0:.3f}\".format(res_f.smoother_results.smoothed_state[0,-1:][0]))\n",
+    "\n",
+    "res_f.plot_components()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.ssm.transition[:, :, 0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Observe that the fitted variances are pretty close to the true variances of 4 and 9.  Further, the individual seasonal components look pretty close to the true seasonal components.  The smoothed level term is kind of close to the true level of 10.  Finally, our diagnostics look solid; the test statistics are small enough to fail to reject our three tests."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Unobserved components (mixed time and frequency domain modeling)\n",
+    "\n",
+    "The second method is an unobserved components model, where the trend is modeled as a fixed intercept and the seasonal components are modeled using 10 constants summing to 0 and trigonometric functions with a primary periodicities of 100 with 2 harmonics total.  Note that this isn't the generating model, as it presupposes that there are more state errors for the shorter seasonal component than in reality. The process for the time series can be written as:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "y_t & = \\mu_t + \\gamma^{(1)}_t + \\gamma^{(2)}_t + \\epsilon_t\\\\\n",
+    "\\mu_{t+1} & = \\mu_t \\\\\n",
+    "\\gamma^{(1)}_{t + 1} &= - \\sum_{j=1}^9 \\gamma^{(1)}_{t + 1 - j} + \\omega^{(1)}_t\\\\\n",
+    "\\gamma^{(2)}_{j, t+1} &= \\gamma^{(2)}_{j, t}\\cos(\\lambda_j) + \\gamma^{*, (2)}_{j, t}\\sin(\\lambda_j) + \\omega^{(2)}_{j,t}, ~j = 1, 2\\\\\n",
+    "\\gamma^{*, (2)}_{j, t+1} &= -\\gamma^{(2)}_{j, t}\\sin(\\lambda_j) + \\gamma^{*, (2)}_{j, t}\\cos(\\lambda_j) + \\omega^{*, (2)}_{j, t}, ~j = 1, 2\\\\\n",
+    "\\end{align}\n",
+    "$$\n",
+    "\n",
+    "where $\\epsilon_t$ is white noise, $\\omega^{(1)}_{t}$ are i.i.d. $N(0, \\sigma^2_1)$, and  $\\omega^{(2)}_{j,t}$ are i.i.d. $N(0, \\sigma^2_2)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = sm.tsa.UnobservedComponents(series, \n",
+    "                                    level='fixed intercept', \n",
+    "                                    seasonal=10,\n",
+    "                                    freq_seasonal=[{'period': 100,\n",
+    "                                                    'harmonics': 2}])\n",
+    "res_tf = model.fit()\n",
+    "print(res_tf.summary())\n",
+    "# The first state variable holds our estimate of the intercept\n",
+    "print(\"fixed intercept estimated as {0:.3f}\".format(res_tf.smoother_results.smoothed_state[0,-1:][0]))\n",
+    "\n",
+    "res_tf.plot_components()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plotted components look good.  However, the estimated variance of the second seasonal term is inflated from reality.  Additionally, we reject the Ljung-Box statistic, indicating we may have remaining autocorrelation after accounting for our components."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Unobserved components (lazy frequency domain modeling)\n",
+    "\n",
+    "The third method is an unobserved components model with a fixed intercept and one seasonal component, which is modeled using trigonometric functions with primary periodicity 100 and 50 harmonics. Note that this isn't the generating model, as it presupposes that there are more harmonics then in reality.  Because the variances are tied together, we are not able to drive the estimated covariance of the non-existent harmonics to 0.  What is lazy about this model specification is that we have not bothered to specify the two different seasonal components and instead chosen to model them using a single component with enough harmonics to cover both.  We will not be able to capture any differences in variances between the two true components.  The process for the time series can be written as:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "y_t & = \\mu_t + \\gamma^{(1)}_t + \\epsilon_t\\\\\n",
+    "\\mu_{t+1} &= \\mu_t\\\\\n",
+    "\\gamma^{(1)}_{t} &= \\sum_{j=1}^{50}\\gamma^{(1)}_{j, t}\\\\\n",
+    "\\gamma^{(1)}_{j, t+1} &= \\gamma^{(1)}_{j, t}\\cos(\\lambda_j) + \\gamma^{*, (1)}_{j, t}\\sin(\\lambda_j) + \\omega^{(1}_{j,t}, ~j = 1, 2, \\dots, 50\\\\\n",
+    "\\gamma^{*, (1)}_{j, t+1} &= -\\gamma^{(1)}_{j, t}\\sin(\\lambda_j) + \\gamma^{*, (1)}_{j, t}\\cos(\\lambda_j) + \\omega^{*, (1)}_{j, t}, ~j = 1, 2, \\dots, 50\\\\\n",
+    "\\end{align}\n",
+    "$$\n",
+    "\n",
+    "where $\\epsilon_t$ is white noise, $\\omega^{(1)}_{t}$ are i.i.d. $N(0, \\sigma^2_1)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = sm.tsa.UnobservedComponents(series, \n",
+    "                                    level='fixed intercept', \n",
+    "                                    freq_seasonal=[{'period': 100}])\n",
+    "res_lf = model.fit()\n",
+    "print(res_lf.summary())\n",
+    "# The first state variable holds our estimate of the intercept\n",
+    "print(\"fixed intercept estimated as {0:.3f}\".format(res_lf.smoother_results.smoothed_state[0,-1:][0]))\n",
+    "\n",
+    "res_lf.plot_components()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that one of our diagnostic tests would be rejected at the .05 level."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Unobserved components (lazy time domain seasonal modeling)\n",
+    "\n",
+    "The fourth method is an unobserved components model with a fixed intercept and a single seasonal component modeled using a time-domain seasonal model of 100 constants. The process for the time series can be written as:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "y_t & =\\mu_t + \\gamma^{(1)}_t + \\epsilon_t\\\\\n",
+    "\\mu_{t+1} &= \\mu_{t} \\\\\n",
+    "\\gamma^{(1)}_{t + 1} &= - \\sum_{j=1}^{99} \\gamma^{(1)}_{t + 1 - j} + \\omega^{(1)}_t\\\\\n",
+    "\\end{align}\n",
+    "$$\n",
+    "\n",
+    "where $\\epsilon_t$ is white noise, $\\omega^{(1)}_{t}$ are i.i.d. $N(0, \\sigma^2_1)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = sm.tsa.UnobservedComponents(series,\n",
+    "                                    level='fixed intercept',\n",
+    "                                    seasonal=100)\n",
+    "res_lt = model.fit(disp=False)\n",
+    "print(res_lt.summary())\n",
+    "# The first state variable holds our estimate of the intercept\n",
+    "print(\"fixed intercept estimated as {0:.3f}\".format(res_lt.smoother_results.smoothed_state[0,-1:][0]))\n",
+    "\n",
+    "res_lt.plot_components()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The seasonal component itself looks good--it is the primary singal.  The estimated variance of the seasonal term is very high ($>10^5$), leading to a lot of uncertainty in our one-step-ahead predictions and slow responsiveness to new data, as evidenced by large errors in one-step ahead predictions and observations. Finally, all three of our diagnostic tests were rejected. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparison of filtered estimates\n",
+    "\n",
+    "The plots below show that explicitly modeling the individual components results in the filtered state being close to the true state within roughly half a period.  The lazy models took longer (almost a full period) to do the same on the combined true state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Assign better names for our seasonal terms\n",
+    "true_seasonal_10_3 = terms[0]\n",
+    "true_seasonal_100_2 = terms[1]\n",
+    "true_sum = true_seasonal_10_3 + true_seasonal_100_2\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_s = np.s_[:50]  # After this they basically agree\n",
+    "fig1 = plt.figure()\n",
+    "ax1 = fig1.add_subplot(111)\n",
+    "h1, = ax1.plot(series.index[time_s], res_f.freq_seasonal[0].filtered[time_s], label='Double Freq. Seas')\n",
+    "h2, = ax1.plot(series.index[time_s], res_tf.seasonal.filtered[time_s], label='Mixed Domain Seas')\n",
+    "h3, = ax1.plot(series.index[time_s], true_seasonal_10_3[time_s], label='True Seasonal 10(3)')\n",
+    "plt.legend([h1, h2, h3], ['Double Freq. Seasonal','Mixed Domain Seasonal','Truth'], loc=2)\n",
+    "plt.title('Seasonal 10(3) component')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_s = np.s_[:50]  # After this they basically agree\n",
+    "fig2 = plt.figure()\n",
+    "ax2 = fig2.add_subplot(111)\n",
+    "h21, = ax2.plot(series.index[time_s], res_f.freq_seasonal[1].filtered[time_s], label='Double Freq. Seas')\n",
+    "h22, = ax2.plot(series.index[time_s], res_tf.freq_seasonal[0].filtered[time_s], label='Mixed Domain Seas')\n",
+    "h23, = ax2.plot(series.index[time_s], true_seasonal_100_2[time_s], label='True Seasonal 100(2)')\n",
+    "plt.legend([h21, h22, h23], ['Double Freq. Seasonal','Mixed Domain Seasonal','Truth'], loc=2)\n",
+    "plt.title('Seasonal 100(2) component')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "time_s = np.s_[:100]\n",
+    "\n",
+    "fig3 = plt.figure()\n",
+    "ax3 = fig3.add_subplot(111)\n",
+    "h31, = ax3.plot(series.index[time_s], res_f.freq_seasonal[1].filtered[time_s] + res_f.freq_seasonal[0].filtered[time_s], label='Double Freq. Seas')\n",
+    "h32, = ax3.plot(series.index[time_s], res_tf.freq_seasonal[0].filtered[time_s] + res_tf.seasonal.filtered[time_s], label='Mixed Domain Seas')\n",
+    "h33, = ax3.plot(series.index[time_s], true_sum[time_s], label='True Seasonal 100(2)')\n",
+    "h34, = ax3.plot(series.index[time_s], res_lf.freq_seasonal[0].filtered[time_s], label='Lazy Freq. Seas')\n",
+    "h35, = ax3.plot(series.index[time_s], res_lt.seasonal.filtered[time_s], label='Lazy Time Seas')\n",
+    "\n",
+    "plt.legend([h31, h32, h33, h34, h35], ['Double Freq. Seasonal','Mixed Domain Seasonal','Truth', 'Lazy Freq. Seas', 'Lazy Time Seas'], loc=1)\n",
+    "plt.title('Seasonal components combined')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Conclusions\n",
+    "\n",
+    "In this notebook, we simulated a time series with two seasonal components of different periods.  We modeled them using structural time series models with (a) two frequency domain components of correct periods and numbers of harmonics, (b) time domain seasonal component for the shorter term and a frequency domain term with correct period and number of harmonics, (c) a single frequency domain term with the longer period and full number of harmonics, and (d) a single time domain term with the longer period.  We saw a variety of diagnostic results, with only the correct generating model, (a), failing to reject any of the tests.  Thus, more flexible seasonal modeling allowing for multiple components with specifiable harmonics can be a useful tool for time series modeling.  Finally, we can represent seasonal components with fewer total states in this way, allowing for the user to attempt to make the bias-variance tradeoff themselves instead of being forced to choose \"lazy\" models, which use a large number of states and incur additional variance as a result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -10,7 +10,6 @@ from warnings import warn
 from statsmodels.compat.collections import OrderedDict
 
 import numpy as np
-import pandas as pd
 from statsmodels.tsa.filters.hp_filter import hpfilter
 from statsmodels.tsa.tsatools import lagmat
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
@@ -61,6 +60,13 @@ class UnobservedComponents(MLEModel):
         `level` must also be True.
     seasonal : int or None, optional
         The period of the seasonal component, if any. Default is None.
+    freq_seasonal: list of dicts or None, optional.
+        Whether (and how) to model seasonal component(s) with trig. functions.
+        If specified, there is one dictionary for each frequency-domain
+        seasonal component.  Each dictionary must have the key, value pair for
+        'period' -- integer and may have a key, value pair for
+        'harmonics' -- integer. If 'harmonics' is not specified in any of the
+        dictionaries, it defaults to the floor of period/2.
     cycle : bool, optional
         Whether or not to include a cycle component. Default is False.
     ar : int or None, optional
@@ -74,7 +80,11 @@ class UnobservedComponents(MLEModel):
     stochastic_trend : bool, optional
         Whether or not any trend component is stochastic. Default is False.
     stochastic_seasonal : bool, optional
-        Whether or not any seasonal component is stochastic. Default is False.
+        Whether or not any seasonal component is stochastic. Default is True.
+    stochastic_freq_seasonal: list of bools, optional
+        Whether or not each seasonal component(s) is (are) stochastic.  Default
+        is True for each component.  The list should be of the same length as
+        freq_seasonal.
     stochastic_cycle : bool, optional
         Whether or not any cycle component is stochastic. Default is False.
     damped_cycle : bool, optional
@@ -204,6 +214,39 @@ class UnobservedComponents(MLEModel):
     time series is available in the results class in the `seasonal`
     attribute.
 
+    ** Freq. Seasonal**
+
+    Each frequency-domain seasonal component is modeled as:
+
+    .. math::
+        \gamma_t &=& \sum_{j=1}^h \gamma_{j, t}
+        \gamma_{j, t+1} &=& \gamma_{j, t}\cos(\lambda_j) \\
+                        && + \gamma^{*}_{j, t}\sin(\lambda_j) + \omega_{j,t} \\
+        \gamma^{*}_{j, t+1} &=^ -\gamma^{(1)}_{j, t}\sin(\lambda_j) \\
+                            &&+ \gamma^{*}_{j, t}\cos(\lambda_j) \\
+                            + \omega^{*}_{j, t}, \\
+        \omega^{*}_{j, t}, \omega_{j, t} &\sim& N(0, \sigma_{\omega^2}
+        \lambda_j = \frac{2 \pi j}{s}
+    where j ranges from 1 to h.
+
+    The periodicity (number of "seasons" in a "year") is s and the number of
+    harmonics is h.  Note that h is configurable to be less than s/2, but
+    s/2 harmonics is sufficient to fully model all seasonal variations of
+    periodicity s.  Like the time domain seasonal term (cf. Seasonal section,
+    above), the inclusion of the error terms allows for the seasonal effects to
+    vary over time.  The argument stochastic_freq_seasonal can be used to set
+    one or more of the seasonal components of this type to be non-random,
+    meaning they will not vary over time.
+
+    This component results in one parameter to be fitted using maximum
+    likelihood: :math: `\sigma_{\omega^2}`, and up to two parameters to be
+    chosen, the number of seasons s and optionally the number of harmonics
+    h, with :math: 1 \leq h \leq \floor(s/2).
+
+    After fitting the model, each unobserved seasonal component modeled in the
+    frequency domain is available in the results class in the `freq_seasonal`
+    attribute.
+    
     **Cycle**
 
     The cyclical component is intended to capture cyclical effects at time
@@ -301,9 +344,13 @@ class UnobservedComponents(MLEModel):
     """
 
     def __init__(self, endog, level=False, trend=False, seasonal=None,
-                 cycle=False, autoregressive=None, exog=None, irregular=False,
-                 stochastic_level=False, stochastic_trend=False,
-                 stochastic_seasonal=True, stochastic_cycle=False,
+                 freq_seasonal=None, cycle=False, autoregressive=None,
+                 exog=None, irregular=False,
+                 stochastic_level=False,
+                 stochastic_trend=False,
+                 stochastic_seasonal=True,
+                 stochastic_freq_seasonal=None,
+                 stochastic_cycle=False,
                  damped_cycle=False, cycle_period_bounds=None,
                  mle_regression=True,
                  **kwargs):
@@ -313,6 +360,15 @@ class UnobservedComponents(MLEModel):
         self.trend = trend
         self.seasonal_periods = seasonal if seasonal is not None else 0
         self.seasonal = self.seasonal_periods > 0
+        if freq_seasonal:
+            self.freq_seasonal_periods = [d['period'] for d in freq_seasonal]
+            self.freq_seasonal_harmonics = [d.get(
+                'harmonics', int(np.floor(d['period'] / 2))) for
+                d in freq_seasonal]
+        else:
+            self.freq_seasonal_periods = []
+            self.freq_seasonal_harmonics = []
+        self.freq_seasonal = any(x > 0 for x in self.freq_seasonal_periods)
         self.cycle = cycle
         self.ar_order = autoregressive if autoregressive is not None else 0
         self.autoregressive = self.ar_order > 0
@@ -321,6 +377,16 @@ class UnobservedComponents(MLEModel):
         self.stochastic_level = stochastic_level
         self.stochastic_trend = stochastic_trend
         self.stochastic_seasonal = stochastic_seasonal
+        if stochastic_freq_seasonal is None:
+            self.stochastic_freq_seasonal = [True] * len(
+                self.freq_seasonal_periods)
+        else:
+            if len(stochastic_freq_seasonal) != len(freq_seasonal):
+                raise ValueError(
+                    "Length of stochastic_freq_seasonal must equal length"
+                    " of freq_seasonal: {!r} vs {!r}".format(
+                        len(stochastic_freq_seasonal), len(freq_seasonal)))
+            self.stochastic_freq_seasonal = stochastic_freq_seasonal
         self.stochastic_cycle = stochastic_cycle
 
         self.damped_cycle = damped_cycle
@@ -416,6 +482,8 @@ class UnobservedComponents(MLEModel):
                 (self.level and self.stochastic_level) or
                 (self.trend and self.stochastic_trend) or
                 (self.seasonal and self.stochastic_seasonal) or
+                (self.freq_seasonal and any(
+                    self.stochastic_freq_seasonal)) or
                 (self.cycle and self.stochastic_cycle) or
                 self.autoregressive):
             warn("Specified model does not contain a stochastic element;"
@@ -425,6 +493,13 @@ class UnobservedComponents(MLEModel):
         if self.seasonal and self.seasonal_periods < 2:
             raise ValueError('Seasonal component must have a seasonal period'
                              ' of at least 2.')
+
+        if self.freq_seasonal:
+            for p in self.freq_seasonal_periods:
+                if p < 2:
+                    raise ValueError(
+                        'Frequency Domain seasonal component must have a '
+                        'seasonal period of at least 2.')
 
         # Create a bitmask holding the level/trend specification
         self.trend_mask = (
@@ -447,10 +522,16 @@ class UnobservedComponents(MLEModel):
         self.regression = self.k_exog > 0
 
         # Model parameters
+        self._k_seasonal_states = (self.seasonal_periods - 1) * self.seasonal
+        self._k_freq_seas_states = (
+            sum(2 * h for h in self.freq_seasonal_harmonics)
+            * self.freq_seasonal)
+        self._k_cycle_states = self.cycle * 2
         k_states = (
             self.level + self.trend +
-            (self.seasonal_periods - 1) * self.seasonal +
-            self.cycle * 2 +
+            self._k_seasonal_states +
+            self._k_freq_seas_states +
+            self._k_cycle_states +
             self.ar_order +
             (not self.mle_regression) * self.k_exog
         )
@@ -458,14 +539,22 @@ class UnobservedComponents(MLEModel):
             self.stochastic_level * self.level +
             self.stochastic_trend * self.trend +
             self.stochastic_seasonal * self.seasonal +
-            self.stochastic_cycle * (self.cycle * 2) +
+            ((sum(2 * h if self.stochastic_freq_seasonal[ix] else 0 for
+                  ix, h in enumerate(self.freq_seasonal_harmonics))) *
+             self.freq_seasonal) +
+            self.stochastic_cycle * (self._k_cycle_states) +
             self.autoregressive
         )
 
+
+        # The ar states are initialized as stationary, so they don't need to be
+        # burned.
+        loglikelihood_burn = kwargs.get('loglikelihood_burn',
+                                        k_states
+                                        - self.ar_order)
+
         # We can still estimate the model with just the irregular component,
         # just need to have one state that does nothing.
-        loglikelihood_burn = kwargs.get('loglikelihood_burn',
-                                        k_states - self.ar_order)
         if k_states == 0:
             if not self.irregular:
                 raise ValueError('Model has no components specified.')
@@ -510,10 +599,11 @@ class UnobservedComponents(MLEModel):
         )
 
         # update _init_keys attached by super
-        self._init_keys += ['level', 'trend', 'seasonal', 'cycle',
-                            'autoregressive', 'exog', 'irregular',
+        self._init_keys += ['level', 'trend', 'seasonal', 'freq_seasonal',
+                            'cycle', 'autoregressive', 'exog', 'irregular',
                             'stochastic_level', 'stochastic_trend',
-                            'stochastic_seasonal', 'stochastic_cycle',
+                            'stochastic_seasonal', 'stochastic_freq_seasonal',
+                            'stochastic_cycle',
                             'damped_cycle', 'cycle_period_bounds',
                             'mle_regression'] + list(kwargs.keys())
         # TODO: I think the kwargs or not attached, need to recover from ???
@@ -524,6 +614,10 @@ class UnobservedComponents(MLEModel):
 
         # Modifications
         kwds['seasonal'] = self.seasonal_periods
+        kwds['freq_seasonal'] = [
+            {'period': p,
+             'harmonics': self.freq_seasonal_harmonics[ix]} for
+            ix, p in enumerate(self.freq_seasonal_periods)]
         kwds['autoregressive'] = self.ar_order
 
         for key, value in kwds.items():
@@ -577,6 +671,33 @@ class UnobservedComponents(MLEModel):
                 self.parameters_state_cov['seasonal_var'] = 1
                 j += 1
             i += n
+        if self.freq_seasonal:
+            for ix, h in enumerate(self.freq_seasonal_harmonics):
+                # These are the \gamma_jt and \gamma^*_jt terms in D&K (3.8)
+                n = 2 * h
+                p = self.freq_seasonal_periods[ix]
+                lambda_p = 2 * np.pi / float(p)
+
+                t = 0  # frequency transition matrix offset
+                for block in range(1, h + 1):
+                    # ibid. eqn (3.7)
+                    self.ssm['design', 0, i+t] = 1.
+
+                    # ibid. eqn (3.8)
+                    cos_lambda_block = np.cos(lambda_p * block)
+                    sin_lambda_block = np.sin(lambda_p * block)
+                    trans = np.array([[cos_lambda_block, sin_lambda_block],
+                                      [-sin_lambda_block, cos_lambda_block]])
+                    trans_s = np.s_[i + t:i + t + 2]
+                    self.ssm['transition', trans_s, trans_s] = trans
+                    t += 2
+
+                if self.stochastic_freq_seasonal[ix]:
+                    self.ssm['selection', i:i + n, j:j + n] = np.eye(n)
+                    cov_key = 'freq_seasonal_var_{!r}'.format(ix)
+                    self.parameters_state_cov[cov_key] = 1
+                    j += n
+                i += n
         if self.cycle:
             self.ssm['design', 0, i] = 1.
             self.parameters_transition['cycle_freq'] = 1
@@ -632,6 +753,24 @@ class UnobservedComponents(MLEModel):
         idx = np.diag_indices(self.ssm.k_posdef)
         self._idx_state_cov = ('state_cov', idx[0], idx[1])
 
+        # Some of the variances may be tied together (repeated parameter usage)
+        # Use list() for compatibility with python 3.5
+        param_keys = list(self.parameters_state_cov.keys())
+        self._var_repetitions = np.ones(self.k_state_cov, dtype=np.int)
+        if self.freq_seasonal:
+            for ix, is_stochastic in enumerate(self.stochastic_freq_seasonal):
+                if is_stochastic:
+                    num_harmonics = self.freq_seasonal_harmonics[ix]
+                    repeat_times = 2 * num_harmonics
+                    cov_key = 'freq_seasonal_var_{!r}'.format(ix)
+                    cov_ix = param_keys.index(cov_key)
+                    self._var_repetitions[cov_ix] = repeat_times
+
+        if self.stochastic_cycle and self.cycle:
+            cov_ix = param_keys.index('cycle_var')
+            self._var_repetitions[cov_ix] = 2
+        self._repeat_any_var = any(self._var_repetitions > 1)
+
     def initialize_state(self):
         # Initialize the AR component as stationary, the rest as approximately
         # diffuse
@@ -645,8 +784,9 @@ class UnobservedComponents(MLEModel):
 
             start = (
                 self.level + self.trend +
-                (self.seasonal_periods - 1) * self.seasonal +
-                self.cycle * 2
+                self._k_seasonal_states +
+                self._k_freq_seas_states +
+                self._k_cycle_states
             )
             end = start + self.ar_order
             selection_stationary = self.ssm['selection', start:end, :, 0]
@@ -732,6 +872,11 @@ class UnobservedComponents(MLEModel):
         if self.stochastic_seasonal:
             _start_params['seasonal_var'] = var_resid
 
+        # Frequency domain seasonal
+        for ix, is_stochastic in enumerate(self.stochastic_freq_seasonal):
+            cov_key = 'freq_seasonal_var_{!r}'.format(ix)
+            _start_params[cov_key] = var_resid
+
         # Cyclical
         if self.cycle:
             _start_params['cycle_var'] = var_resid
@@ -786,6 +931,16 @@ class UnobservedComponents(MLEModel):
                 param_names.append('sigma2.trend')
             elif key == 'seasonal_var':
                 param_names.append('sigma2.seasonal')
+            elif key.startswith('freq_seasonal_var_'):
+                # There are potentially multiple frequency domain seasonal terms
+                idx_fseas_comp = int(key[-1])
+                periodicity = self.freq_seasonal_periods[idx_fseas_comp]
+                harmonics = self.freq_seasonal_harmonics[idx_fseas_comp]
+                freq_seasonal_name = "{p}({h})".format(
+                    p=repr(periodicity),
+                    h=repr(harmonics))
+                param_names.append(
+                    'sigma2.' + 'freq_seasonal_' + freq_seasonal_name)
             elif key == 'cycle_var':
                 param_names.append('sigma2.cycle')
             elif key == 'cycle_freq':
@@ -907,11 +1062,8 @@ class UnobservedComponents(MLEModel):
         # State covariance
         if self.k_state_cov > 0:
             variances = params[offset:offset+self.k_state_cov]
-            if self.stochastic_cycle and self.cycle:
-                if self.autoregressive:
-                    variances = np.r_[variances[:-1], variances[-2:]]
-                else:
-                    variances = np.r_[variances, variances[-1]]
+            if self._repeat_any_var:
+                variances = np.repeat(variances, self._var_repetitions)
             self.ssm[self._idx_state_cov] = variances
             offset += self.k_state_cov
 
@@ -980,6 +1132,12 @@ class UnobservedComponentsResults(MLEResults):
         # Save _init_kwds
         self._init_kwds = self.model._get_init_kwds()
 
+        # Save number of states by type
+        self._k_states_by_type = {
+            'seasonal': self.model._k_seasonal_states,
+            'freq_seasonal': self.model._k_freq_seas_states,
+            'cycle': self.model._k_cycle_states}
+
         # Save the model specification
         self.specification = Bunch(**{
             # Model options
@@ -987,6 +1145,9 @@ class UnobservedComponentsResults(MLEResults):
             'trend': self.model.trend,
             'seasonal_periods': self.model.seasonal_periods,
             'seasonal': self.model.seasonal,
+            'freq_seasonal': self.model.freq_seasonal,
+            'freq_seasonal_periods': self.model.freq_seasonal_periods,
+            'freq_seasonal_harmonics': self.model.freq_seasonal_harmonics,
             'cycle': self.model.cycle,
             'ar_order': self.model.ar_order,
             'autoregressive': self.model.autoregressive,
@@ -994,6 +1155,7 @@ class UnobservedComponentsResults(MLEResults):
             'stochastic_level': self.model.stochastic_level,
             'stochastic_trend': self.model.stochastic_trend,
             'stochastic_seasonal': self.model.stochastic_seasonal,
+            'stochastic_freq_seasonal': self.model.stochastic_freq_seasonal,
             'stochastic_cycle': self.model.stochastic_cycle,
 
             'damped_cycle': self.model.damped_cycle,
@@ -1118,6 +1280,82 @@ class UnobservedComponentsResults(MLEResults):
         return out
 
     @property
+    def freq_seasonal(self):
+        """
+        Estimates of unobserved frequency domain seasonal component(s)
+
+        Returns
+        -------
+        out: list of Bunch instances
+            Each item has the following attributes:
+
+            - `filtered`: a time series array with the filtered estimate of
+                          the component
+            - `filtered_cov`: a time series array with the filtered estimate of
+                          the variance/covariance of the component
+            - `smoothed`: a time series array with the smoothed estimate of
+                          the component
+            - `smoothed_cov`: a time series array with the smoothed estimate of
+                          the variance/covariance of the component
+            - `offset`: an integer giving the offset in the state vector where
+                        this component begins
+        """
+        # If present, freq_seasonal components always follows level/trend
+        #  and seasonal.
+
+        # There are 2 * (harmonics) seasonal states per freq_seasonal
+        # component.
+        # The sum of every other state enters the measurement equation.
+        # Additionally, there can be multiple components of this type.
+        # These facts make this property messier in implementation than the
+        # others.
+        # Fortunately, the states are conditionally mutually independent
+        # (conditional on previous timestep's states), so that the calculations
+        # of the variances are simple summations of individual variances and
+        # the calculation of the returned state is likewise a summation.
+        out = []
+        spec = self.specification
+        if spec.freq_seasonal:
+            previous_states_offset = int(spec.trend + spec.level
+                                         + self._k_states_by_type['seasonal'])
+            previous_f_seas_offset = 0
+            for ix, h in enumerate(spec.freq_seasonal_harmonics):
+                offset = previous_states_offset + previous_f_seas_offset
+
+                period = spec.freq_seasonal_periods[ix]
+
+                # Only the gamma_jt terms enter the measurement equation (cf.
+                # D&K 2012 (3.7))
+                states_in_sum = np.arange(0, 2 * h, 2)
+
+                filtered_state = np.sum(
+                    [self.filtered_state[offset + j] for j in states_in_sum],
+                    axis=0)
+                filtered_cov = np.sum(
+                    [self.filtered_state_cov[offset + j, offset + j] for j in
+                     states_in_sum], axis=0)
+
+
+                item = Bunch(
+                    filtered=filtered_state,
+                    filtered_cov=filtered_cov,
+                    smoothed=None, smoothed_cov=None,
+                    offset=offset,
+                    pretty_name='seasonal {p}({h})'.format(p=repr(period),
+                                                           h=repr(h)))
+                if self.smoothed_state is not None:
+                    item.smoothed = np.sum(
+                        [self.smoothed_state[offset+j] for j in states_in_sum],
+                        axis=0)
+                if self.smoothed_state_cov is not None:
+                    item.smoothed_cov = np.sum(
+                        [self.smoothed_state_cov[offset+j, offset+j]
+                         for j in states_in_sum], axis=0)
+                out.append(item)
+                previous_f_seas_offset += 2 * h
+        return out
+
+    @property
     def cycle(self):
         """
         Estimates of unobserved cycle component
@@ -1138,7 +1376,8 @@ class UnobservedComponentsResults(MLEResults):
             - `offset`: an integer giving the offset in the state vector where
                         this component begins
         """
-        # If present, cycle always follows level/trend and seasonal
+        # If present, cycle always follows level/trend, seasonal, and freq
+        #  seasonal.
         # Note that we return only the first cyclical state, but there are
         # in fact 2 cyclical states. The second cyclical state is not simply
         # a lag of the first cyclical state, but the first cyclical state is
@@ -1146,8 +1385,9 @@ class UnobservedComponentsResults(MLEResults):
         out = None
         spec = self.specification
         if spec.cycle:
-            offset = int(spec.trend + spec.level +
-                         spec.seasonal * (spec.seasonal_periods - 1))
+            offset = int(spec.trend + spec.level
+                         + self._k_states_by_type['seasonal']
+                         + self._k_states_by_type['freq_seasonal'])
             out = Bunch(filtered=self.filtered_state[offset],
                         filtered_cov=self.filtered_state_cov[offset, offset],
                         smoothed=None, smoothed_cov=None,
@@ -1179,15 +1419,17 @@ class UnobservedComponentsResults(MLEResults):
             - `offset`: an integer giving the offset in the state vector where
                         this component begins
         """
-        # If present, autoregressive always follows level/trend, seasonal, and
-        # cyclical. If it is an AR(p) model, then there are p associated
+        # If present, autoregressive always follows level/trend, seasonal,
+        # freq seasonal, and cyclical.
+        # If it is an AR(p) model, then there are p associated
         # states, but the second - pth states are just lags of the first state.
         out = None
         spec = self.specification
         if spec.autoregressive:
-            offset = int(spec.trend + spec.level +
-                         spec.seasonal * (spec.seasonal_periods - 1) +
-                         2 * spec.cycle)
+            offset = int(spec.trend + spec.level
+                         + self._k_states_by_type['seasonal']
+                         + self._k_states_by_type['freq_seasonal']
+                         + self._k_states_by_type['cycle'])
             out = Bunch(filtered=self.filtered_state[offset],
                         filtered_cov=self.filtered_state_cov[offset, offset],
                         smoothed=None, smoothed_cov=None,
@@ -1220,7 +1462,7 @@ class UnobservedComponentsResults(MLEResults):
                         this component begins
         """
         # If present, state-vector regression coefficients always are last
-        # (i.e. they follow level/trend, seasonal, cyclical, and
+        # (i.e. they follow level/trend, seasonal, freq seasonal, cyclical, and
         # autoregressive states). There is one state associated with each
         # regressor, and all are returned here.
         out = None
@@ -1233,10 +1475,11 @@ class UnobservedComponentsResults(MLEResults):
                               ' available in the parameters list, not as part'
                               ' of the state vector.', OutputWarning)
             else:
-                offset = int(spec.trend + spec.level +
-                             spec.seasonal * (spec.seasonal_periods - 1) +
-                             spec.cycle * (1 + spec.stochastic_cycle) +
-                             spec.ar_order)
+                offset = int(spec.trend + spec.level
+                             + self._k_states_by_type['seasonal']
+                             + self._k_states_by_type['freq_seasonal']
+                             + self._k_states_by_type['cycle']
+                             + spec.ar_order)
                 start = offset
                 end = offset + spec.k_exog
                 out = Bunch(
@@ -1254,7 +1497,8 @@ class UnobservedComponentsResults(MLEResults):
 
     def plot_components(self, which=None, alpha=0.05,
                         observed=True, level=True, trend=True,
-                        seasonal=True, cycle=True, autoregressive=True,
+                        seasonal=True, freq_seasonal=True,
+                        cycle=True, autoregressive=True,
                         legend_loc='upper right', fig=None, figsize=None):
         """
         Plot the estimated components of the model.
@@ -1275,6 +1519,9 @@ class UnobservedComponentsResults(MLEResults):
         seasonal : boolean, optional
             Whether or not to plot the seasonal component, if applicable.
             Default is True.
+        freq_seasonal: boolean, optional
+            Whether or not to plot the frequency domain seasonal component(s),
+            if applicable. Default is True.
         cycle : boolean, optional
             Whether or not to plot the cyclical component, if applicable.
             Default is True.
@@ -1298,8 +1545,9 @@ class UnobservedComponentsResults(MLEResults):
         1. Level
         2. Trend
         3. Seasonal
-        4. Cycle
-        5. Autoregressive
+        4. Freq Seasonal
+        5. Cycle
+        6. Autoregressive
 
         Specific subplots will be removed if the component is not present in
         the estimated model or if the corresponding keywork argument is set to
@@ -1318,13 +1566,23 @@ class UnobservedComponentsResults(MLEResults):
 
         # Determine which plots we have
         spec = self.specification
-        components = OrderedDict([
+
+        comp = [
             ('level', level and spec.level),
             ('trend', trend and spec.trend),
             ('seasonal', seasonal and spec.seasonal),
-            ('cycle', cycle and spec.cycle),
-            ('autoregressive', autoregressive and spec.autoregressive),
-        ])
+        ]
+
+        if freq_seasonal and spec.freq_seasonal:
+            for ix, _ in enumerate(spec.freq_seasonal_periods):
+                key = 'freq_seasonal_{!r}'.format(ix)
+                comp.append((key, True))
+
+        comp.extend(
+            [('cycle', cycle and spec.cycle),
+             ('autoregressive', autoregressive and spec.autoregressive)])
+
+        components = OrderedDict(comp)
 
         llb = self.filter_results.loglikelihood_burn
 
@@ -1385,7 +1643,19 @@ class UnobservedComponentsResults(MLEResults):
             ax = fig.add_subplot(k_plots, 1, plot_idx)
             plot_idx += 1
 
-            component_bunch = getattr(self, component)
+            try:
+                component_bunch = getattr(self, component)
+                title = component.title()
+            except AttributeError:
+                # This might be a freq_seasonal component, of which there are
+                #  possibly multiple bagged up in property freq_seasonal
+                if component.startswith('freq_seasonal_'):
+                    ix = int(component.replace('freq_seasonal_', ''))
+                    big_bunch = getattr(self, 'freq_seasonal')
+                    component_bunch = big_bunch[ix]
+                    title = component_bunch.pretty_name
+                else:
+                    raise
 
             # Check for a valid estimation type
             if which not in component_bunch:
@@ -1397,7 +1667,7 @@ class UnobservedComponentsResults(MLEResults):
             value = component_bunch[which]
 
             # Plot
-            state_label = '%s (%s)' % (component.title(), which)
+            state_label = '%s (%s)' % (title, which)
             ax.plot(dates[llb:], value[llb:], label=state_label)
 
             # Get confidence intervals
@@ -1409,12 +1679,12 @@ class UnobservedComponentsResults(MLEResults):
                     dates[llb:], ci_lower[llb:], ci_upper[llb:], alpha=0.2
                 )
                 ci_label = ('$%.3g \\%%$ confidence interval'
-                            % ((1 - alpha)*100))
+                            % ((1 - alpha) * 100))
 
             # Legend
             ax.legend(loc=legend_loc)
 
-            ax.set_title('%s component' % component.title())
+            ax.set_title('%s component' % title)
 
         # Add a note if first observations excluded
         if llb > 0:
@@ -1531,6 +1801,18 @@ class UnobservedComponentsResults(MLEResults):
             if self.specification.stochastic_seasonal:
                 seasonal_name = 'stochastic ' + seasonal_name
             model_name.append(seasonal_name)
+
+        if self.specification.freq_seasonal:
+            for ix, is_stochastic in enumerate(
+                    self.specification.stochastic_freq_seasonal):
+                periodicity = self.specification.freq_seasonal_periods[ix]
+                harmonics = self.specification.freq_seasonal_harmonics[ix]
+                freq_seasonal_name = "freq_seasonal({p}({h}))".format(
+                    p=repr(periodicity),
+                    h=repr(harmonics))
+                if is_stochastic:
+                    freq_seasonal_name = 'stochastic ' + freq_seasonal_name
+                model_name.append(freq_seasonal_name)
 
         if self.specification.cycle:
             cycle_name = 'cycle'

--- a/statsmodels/tsa/statespace/tests/results/results_structural.py
+++ b/statsmodels/tsa/statespace/tests/results/results_structural.py
@@ -164,11 +164,21 @@ cycle = {
 seasonal = {
     'models': [{'irregular': True, 'seasonal': 4}],
     'params': [38.1704278, 0.1],
-    'llf': -655.3337155,
-    'kwargs': {},
+    'llf': -678.8138005,
+    'kwargs': {'loglikelihood_burn': 0},
     'rtol': 1e-6
 }
 
+freq_seasonal = {
+    'models': [{'irregular': True,
+                'freq_seasonal': [{'period': 5}]}],
+    'params': [38.95352534, 0.05],
+    'llf': -688.9697249,
+    'rtol': 1e-6,
+    'kwargs': {
+        'loglikelihood_burn': 0  # No idea why KFAS includes all data in this
+    }
+}
 reg = {
     # Note: The test needs to fill in exog=np.log(dta['realgdp'])
     'models': [

--- a/statsmodels/tsa/statespace/tests/results/test_ucm.R
+++ b/statsmodels/tsa/statespace/tests/results/test_ucm.R
@@ -94,12 +94,23 @@ print(exp(res_cycle$optim.out$par)) # [37.57197224]
 print(res_cycle$optim.out$value)    # 672.3102588
 
 # Seasonal (with fixed period=4, seasonal variance=0.1)
-mod_seasonal <- SSModel(dta$unemp ~ -1 + SSMseasonal(4, Q=matrix(0.1), sea.type='dummy', P1=diag(1)*1e6), H=matrix(NA))
+# Note: matching this requires setting loglikelihood_burn=0
+mod_seasonal <- SSModel(dta$unemp ~ -1 + SSMseasonal(4, Q=matrix(0.1), sea.type='dummy', P1=diag(rep(1e6, 3))), H=matrix(NA))
 res_seasonal <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_seasonal,
                        method="BFGS", control=list(REPORT=1, trace=1))
 
-print(exp(res_seasonal$optim.out$par)) # [38.1704278]
-print(res_seasonal$optim.out$value)    # 655.3337155
+print(exp(res_seasonal$optim.out$par)) # [38.17043009]
+print(res_seasonal$optim.out$value)    # 678.8138005
+
+# Trig Seasonal (with fixed period=5, full number of harmonics, seasonal variance=.05)
+# Note: matching this requires setting loglikelihood_burn=0
+mod_trig_seasonal <- SSModel(dta$unemp ~ -1 + SSMseasonal(5, Q=0.05, sea.type='trigonometric', P1=diag(rep(1e6, 4))), H=matrix(NA))
+res_trig_seasonal <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_trig_seasonal,
+                       method="BFGS", control=list(REPORT=1, trace=1))
+
+print(exp(res_trig_seasonal$optim.out$par)) # [38.95352534]
+print(res_trig_seasonal$optim.out$value)    # 688.9697249
+
 
 # Regression
 # Note: matching this requires setting loglikelihood_burn = 0

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -141,7 +141,7 @@ def test_fixed_slope():
     run_ucm('fixed_slope')
 
 
-def test_fixed_slope():
+def test_fixed_slope_warn():
     # Clear warnings
     structural.__warningregistry__ = {}
 
@@ -182,6 +182,10 @@ def test_cycle():
 
 def test_seasonal():
     run_ucm('seasonal')
+
+
+def test_freq_seasonal():
+    run_ucm('freq_seasonal')
 
 
 def test_reg():
@@ -355,3 +359,89 @@ def test_predict_custom_index():
     res = mod.smooth(mod.start_params)
     out = res.predict(start=1, end=1, index=['a'])
     assert_equal(out.index.equals(pd.Index(['a'])), True)
+
+
+def test_matrices_somewhat_complicated_model():
+    values = dta.copy()
+
+    model = UnobservedComponents(values['unemp'],
+                                 level='lltrend',
+                                 freq_seasonal=[{'period': 4},
+                                                {'period': 9, 'harmonics': 3}],
+                                 cycle=True,
+                                 cycle_period_bounds=[2, 30],
+                                 damped_cycle=True,
+                                 stochastic_freq_seasonal=[True, False],
+                                 stochastic_cycle=True
+                                 )
+    # Selected parameters
+    params = [1,  # irregular_var
+              3, 4,  # lltrend parameters:  level_var, trend_var
+              5,   # freq_seasonal parameters: freq_seasonal_var_0
+              # cycle parameters: cycle_var, cycle_freq, cycle_damp
+              6, 2*np.pi/30., .9
+              ]
+    model.update(params)
+
+    # Check scalar properties
+    assert_equal(model.k_states, 2 + 4 + 6 + 2)
+    assert_equal(model.k_state_cov, 2 + 1 + 0 + 1)
+    assert_equal(model.loglikelihood_burn, 2 + 4 + 6 + 2)
+    assert_allclose(model.ssm.k_posdef, 2 + 4 + 0 + 2)
+    assert_equal(model.k_params, len(params))
+
+    # Check the statespace model matrices against hand-constructed answers
+    # We group the terms by the component
+    expected_design = np.r_[[1, 0],
+                            [1, 0, 1, 0],
+                            [1, 0, 1, 0, 1, 0],
+                            [1, 0]].reshape(1, 14)
+    assert_allclose(model.ssm.design[:, :, 0], expected_design)
+
+    expected_transition = __direct_sum([
+        np.array([[1, 1],
+                  [0, 1]]),
+        np.array([[ 0, 1, 0, 0],
+                  [-1, 0, 0, 0],
+                  [0, 0, -1,  0],
+                  [0, 0,  0, -1]]),
+        np.array([[ np.cos(2*np.pi*1/9.), np.sin(2*np.pi*1/9.), 0, 0, 0, 0],
+                  [-np.sin(2*np.pi*1/9.), np.cos(2*np.pi*1/9.), 0, 0, 0, 0],
+                  [0, 0,  np.cos(2*np.pi*2/9.), np.sin(2*np.pi*2/9.), 0, 0],
+                  [0, 0, -np.sin(2*np.pi*2/9.), np.cos(2*np.pi*2/9.), 0, 0],
+                  [0, 0, 0, 0,  np.cos(2*np.pi/3.), np.sin(2*np.pi/3.)],
+                  [0, 0, 0, 0, -np.sin(2*np.pi/3.), np.cos(2*np.pi/3.)]]),
+        np.array([[.9*np.cos(2*np.pi/30.), .9*np.sin(2*np.pi/30.)],
+                 [-.9*np.sin(2*np.pi/30.), .9*np.cos(2*np.pi/30.)]])
+    ])
+    assert_allclose(
+        model.ssm.transition[:, :, 0], expected_transition, atol=1e-7)
+
+    # Since the second seasonal term is not stochastic,
+    # the dimensionality of the state disturbance is 14 - 6 = 8
+    expected_selection = np.zeros((14, 14 - 6))
+    expected_selection[0:2, 0:2] = np.eye(2)
+    expected_selection[2:6, 2:6] = np.eye(4)
+    expected_selection[-2:, -2:] = np.eye(2)
+    assert_allclose(model.ssm.selection[:, :, 0], expected_selection)
+
+    expected_state_cov = __direct_sum([
+        np.diag(params[1:3]),
+        np.eye(4)*params[3],
+        np.eye(2)*params[4]
+    ])
+    assert_allclose(model.ssm.state_cov[:, :, 0], expected_state_cov)
+
+
+def __direct_sum(square_matrices):
+    """Compute the matrix direct sum of an iterable of square numpy 2-d arrays
+    """
+    new_shape = np.sum([m.shape for m in square_matrices], axis=0)
+    new_array = np.zeros(new_shape)
+    offset = 0
+    for m in square_matrices:
+        rows, cols = m.shape
+        assert rows == cols
+        new_array[offset:offset + rows, offset:offset + rows] = m
+        offset += rows
+    return new_array


### PR DESCRIPTION
Previously, we had implemented the main time domain seasonal component, which
is restrictive when the periodicity is very high or the seasonality can be
more parsimoniously represented by trigonometric terms.

Additionally, we were only able to use a single seasonal component.  This
commit allows for multiple seasonal components in the frequency domain and
for mixing of the two types.

Also
   - Change offset for regression coefficients when cycle is included.
     Cycle is two states regardless of if it is stochastic.  Therefore,
     the offset should always be 2 instead of possibly 1 for a deterministic
     cycle.